### PR TITLE
Upgrade to use org.apache.commons.lang3.StringEscapeUtils.escapeXml()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,9 +75,9 @@
 		</dependency>
 		
 	    <dependency>
-	      <groupId>commons-lang</groupId>
-	      <artifactId>commons-lang</artifactId>
-	      <version>2.4</version>
+	      <groupId>org.apache.commons</groupId>
+	      <artifactId>commons-lang3</artifactId>
+	      <version>3.4</version>
 	    </dependency>
 
 		<dependency>

--- a/src/com/comcast/cns/io/CNSAttributePopulator.java
+++ b/src/com/comcast/cns/io/CNSAttributePopulator.java
@@ -15,7 +15,7 @@
  */
 package com.comcast.cns.io;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 
 import com.comcast.cns.model.CNSSubscription;
 import com.comcast.cns.model.CNSSubscriptionAttributes;
@@ -110,7 +110,7 @@ public class CNSAttributePopulator {
 		if (attr.getDisplayName() != null && !attr.getDisplayName().isEmpty()) {
 			out.append("\t\t\t<entry>\n");
 			out.append("\t\t\t\t<key>DisplayName</key>\n");
-			out.append("\t\t\t\t<value>").append(StringEscapeUtils.escapeHtml(attr.getDisplayName())).append("</value>\n");
+			out.append("\t\t\t\t<value>").append(StringEscapeUtils.escapeHtml4(attr.getDisplayName())).append("</value>\n");
 			out.append("\t\t\t</entry>\n");
 		}
 

--- a/src/com/comcast/cqs/io/CQSMessagePopulator.java
+++ b/src/com/comcast/cqs/io/CQSMessagePopulator.java
@@ -18,7 +18,7 @@ package com.comcast.cqs.io;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 
 import com.comcast.cqs.model.CQSBatchResultErrorEntry;
 import com.comcast.cqs.model.CQSMessage;

--- a/tests/com/comcast/cmb/test/tools/CNSTestingUtils.java
+++ b/tests/com/comcast/cmb/test/tools/CNSTestingUtils.java
@@ -36,7 +36,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.log4j.Logger;
 
 import com.amazonaws.util.json.JSONWriter;


### PR DESCRIPTION
The old ver 2.x org.apache.commons.lang.StringEscapeUtils.escapeXml has a serious bug. It escapes two bytes emoji unicode to &#decimal_value; which is not valid XML syntax. And it causes the AWS SDK to throw exception.

Upgrade to use version 3.x use org.apache.commons.lang3.StringEscapeUtils.escapeXml() fixed this bug.
